### PR TITLE
Create JSON from complete object

### DIFF
--- a/src/routes/post-news.tsx
+++ b/src/routes/post-news.tsx
@@ -102,8 +102,7 @@ export default function PostNews() {
       });
       return;
     }
-    console.log(`url: ${url.length}`);
-    console.log(`body: ${body.length}`);
+
     if (url.length === 0 && body.length === 0) {
       toast({
         title: 'One of a URL or Body is required',
@@ -115,13 +114,15 @@ export default function PostNews() {
       return;
     }
 
-    setFinalPost(`{
-  "p": "ons",
-  "op": "post",
-  "title": "${title}"${url ? `,\n  "url": "${url}"` : ''}${
-      body ? `,\n  "body": ${JSON.stringify(body)}` : ''
-    }
-}`);
+    const postObject = {
+      p: 'ons',
+      op: 'post',
+      title,
+      ...(url.length > 0 && { url }),
+      ...(body.length > 0 && { body }),
+    };
+
+    setFinalPost(JSON.stringify(postObject));
 
     onOpen();
   };

--- a/src/routes/post-news.tsx
+++ b/src/routes/post-news.tsx
@@ -56,6 +56,7 @@ export default function PostNews() {
   const [title, setTitle] = useControllableState({ defaultValue: '' });
   const [url, setUrl] = useControllableState({ defaultValue: '' });
   const [body, setBody] = useControllableState({ defaultValue: '' });
+  const [author, setAuthor] = useControllableState({ defaultValue: '' });
   const [finalPost, setFinalPost] = useControllableState({ defaultValue: '' });
   const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = useToast();
@@ -120,9 +121,10 @@ export default function PostNews() {
       title,
       ...(url.length > 0 && { url }),
       ...(body.length > 0 && { body }),
+      ...(author.length > 0 && { author }),
     };
 
-    setFinalPost(JSON.stringify(postObject));
+    setFinalPost(JSON.stringify(postObject, null, 2));
 
     onOpen();
   };
@@ -224,6 +226,15 @@ export default function PostNews() {
                 placeholder="Add a link (optional)"
                 fontSize={['xs', 'sm', 'xl']}
                 onChange={e => setUrl(e.target.value.trim())}
+              />
+            </FormControl>
+            <FormControl id="author">
+              <FormLabel fontSize={['sm', 'sm', 'xl']}>Author</FormLabel>
+              <Input
+                type="text"
+                placeholder="Add an author (optional)"
+                fontSize={['xs', 'sm', 'xl']}
+                onChange={e => setAuthor(e.target.value.trim())}
               />
             </FormControl>
             <FormControl>

--- a/src/routes/post-news.tsx
+++ b/src/routes/post-news.tsx
@@ -120,8 +120,8 @@ export default function PostNews() {
       op: 'post',
       title,
       ...(url.length > 0 && { url }),
-      ...(body.length > 0 && { body }),
       ...(author.length > 0 && { author }),
+      ...(body.length > 0 && { body }),
     };
 
     setFinalPost(JSON.stringify(postObject, null, 2));


### PR DESCRIPTION
The current code resulted in some weird results with more complicated markdown files. This aims to resolve that by creating the JS object first then using `JSON.stringify()` on the whole thing vs just the body text.