### PR TITLE
Add new back-end API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.dev.vars

--- a/functions/api/content/[id].ts
+++ b/functions/api/content/[id].ts
@@ -65,15 +65,12 @@ export async function getOrFetchInscriptionContent(env: Env, id: string) {
   if (kvContent !== undefined) {
     return kvContent;
   }
-  console.log(`id: ${id}`);
   // look up info
-  console.log('fetching info');
   const info = await getOrFetchInscriptionInfo(env, id).catch(() => undefined);
   if (info === undefined || Object.keys(info).length === 0) {
     throw new Error(`Inscription info not found for ${id}`);
   }
   // look up content if not found
-  console.log('fetching content');
   let content = await fetchContentFromHiro(id).catch(() => {
     () => undefined;
   });
@@ -83,7 +80,6 @@ export async function getOrFetchInscriptionContent(env: Env, id: string) {
   if (content === undefined || content.body === null) {
     throw new Error(`Inscription content not found for ID: ${id}`);
   }
-  console.log('building metadata');
   // build metadata based on info
   const metadata: InscriptionMeta = {
     id: info.id,
@@ -96,7 +92,6 @@ export async function getOrFetchInscriptionContent(env: Env, id: string) {
   const contentKey = `inscription-${id}-content`;
   const contentResponse = content.clone();
   await env.ORD_NEWS_INDEX.put(contentKey, await content.arrayBuffer(), { metadata });
-  console.log('returning data');
   // return data
   return {
     content: contentResponse,

--- a/functions/api/info/[id].ts
+++ b/functions/api/info/[id].ts
@@ -1,5 +1,5 @@
 import { EventContext } from '@cloudflare/workers-types';
-import { createResponse, fetchInfoFromOrdApi } from '../../../lib/api-helpers';
+import { createResponse, fetchInfoFromHiro, fetchInfoFromOrdApi } from '../../../lib/api-helpers';
 import { Env, InscriptionInfo, InscriptionMeta } from '../../../lib/api-types';
 
 export async function onRequest(context: EventContext<Env, any, any>): Promise<Response> {
@@ -42,7 +42,9 @@ export async function getOrFetchInscriptionInfo(env: Env, id: string) {
     return kvInfo;
   }
   // look up info if not found
-  const info = await fetchInfoFromOrdApi(id).catch(() => undefined);
+  const info = await fetchInfoFromHiro(id).catch(async () => {
+    return await fetchInfoFromOrdApi(id).catch(() => undefined);
+  });
   if (info === undefined || Object.keys(info).length === 0) {
     throw new Error(`Inscription info not found for ${id}`);
   }

--- a/functions/api/info/[id].ts
+++ b/functions/api/info/[id].ts
@@ -42,9 +42,10 @@ export async function getOrFetchInscriptionInfo(env: Env, id: string) {
     return kvInfo;
   }
   // look up info if not found
-  const info = await fetchInfoFromHiro(id).catch(async () => {
-    return await fetchInfoFromOrdApi(id).catch(() => undefined);
-  });
+  let info = await fetchInfoFromHiro(id).catch(() => undefined);
+  if (info === undefined) {
+    info = await fetchInfoFromOrdApi(id).catch(() => undefined);
+  }
   if (info === undefined || Object.keys(info).length === 0) {
     throw new Error(`Inscription info not found for ${id}`);
   }

--- a/functions/api/reset-data.ts
+++ b/functions/api/reset-data.ts
@@ -3,7 +3,6 @@ import { createResponse } from '../../lib/api-helpers';
 import { Env } from '../../lib/api-types';
 
 export async function onRequest(context: EventContext<Env, any, any>): Promise<Response> {
-  /*
   try {
     const { env } = context;
     if (!env.PREVIEW) {
@@ -17,6 +16,5 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
   } catch (err) {
     return createResponse(err, 500);
   }
-  */
-  return createResponse('Feature not available.', 403);
+  // return createResponse('Feature not available.', 403);
 }

--- a/functions/api/reset-data.ts
+++ b/functions/api/reset-data.ts
@@ -5,7 +5,7 @@ import { Env } from '../../lib/api-types';
 export async function onRequest(context: EventContext<Env, any, any>): Promise<Response> {
   try {
     const { env } = context;
-    if (!env.PREVIEW) {
+    if (!!env.PREVIEW) {
       return createResponse('Feature not available in production.', 403);
     }
     const kvKeyList = await env.ORD_NEWS_INDEX.list();
@@ -16,5 +16,4 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
   } catch (err) {
     return createResponse(err, 500);
   }
-  // return createResponse('Feature not available.', 403);
 }

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -1,10 +1,5 @@
 import throttledQueue from 'throttled-queue';
-import {
-  HiroApiInscription,
-  HiroApiResponse,
-  InscriptionInfo,
-  OrdApiInscription,
-} from './api-types';
+import { HiroApiInscription, InscriptionInfo, OrdApiInscription } from './api-types';
 
 // throttle to 1 request per second
 const throttle = throttledQueue(1, 1000, true);
@@ -37,7 +32,8 @@ export function createResponse(data: unknown, status = 200) {
 // fetchs hiro api inscription results
 // and formats/returns them as InscriptionInfo
 export async function fetchInfoFromHiro(id: string): Promise<InscriptionInfo> {
-  const url = new URL(`/inscriptions/${id}`, hiroUrlBase);
+  const url = new URL(`/ordinals/v1/inscriptions/${id}`, hiroUrlBase);
+  //console.log(`fetching info: ${url.toString()}`);
   const data = await fetchUrl(url.toString()).catch(() => {});
   if (data === undefined || Object.keys(data).length === 0) {
     throw new Error(`fetchInfoFromHiro: ${url} returned no data`);
@@ -84,7 +80,9 @@ export async function fetchInfoFromOrdApi(id: string): Promise<InscriptionInfo> 
 // fetchs hiro api content results
 export async function fetchContentFromHiro(id: string): Promise<Response> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}/content`, hiroUrlBase);
-  const response = await throttle(() => fetch(url.toString()).catch(() => {}));
+  console.log(`fetching content: ${url.toString()}`);
+  const response = await fetch(url.toString()).catch(() => {});
+  console.log(`fetch complete`);
   if (response === undefined) {
     throw new Error(`fetchContentFromHiro: ${url} returned no data`);
   }
@@ -94,7 +92,7 @@ export async function fetchContentFromHiro(id: string): Promise<Response> {
 // fetches ordinals.com/content results
 export async function fetchContentFromOrdinals(id: string): Promise<Response> {
   const url = new URL(`/content/${id}`, ordinalsUrlBase);
-  const response = await throttle(() => fetch(url.toString()).catch(() => {}));
+  const response = await fetch(url.toString()).catch(() => {});
   // const data = await fetchUrl(url.toString()).catch(() => {});
   if (response === undefined) {
     throw new Error(`fetchContentFromOrdinals: ${url} returned no data`);

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -1,5 +1,10 @@
 import throttledQueue from 'throttled-queue';
-import { InscriptionInfo, OrdApiInscription } from './api-types';
+import {
+  HiroApiInscription,
+  HiroApiResponse,
+  InscriptionInfo,
+  OrdApiInscription,
+} from './api-types';
 
 // throttle to 1 request per second
 const throttle = throttledQueue(1, 1000, true);
@@ -15,6 +20,40 @@ export async function fetchUrl(url: string) {
     }
   }
   throw new Error(`fetchUrl: ${url} ${response.status} ${response.statusText}`);
+}
+
+// base API definitions
+export const ordinalsUrlBase = new URL('https://ordinals.com/');
+export const ordApiUrlBase = new URL('https://ordapi.xyz/');
+export const hiroUrlBase = new URL('https://api.hiro.so/');
+
+// takes data and status code and returns a Response object
+export function createResponse(data: unknown, status = 200) {
+  return new Response(typeof data === 'string' ? data : JSON.stringify(data, null, 2), {
+    status: status,
+  });
+}
+
+// fetchs hiro api inscription results
+// and formats/returns them as InscriptionInfo
+export async function fetchInfoFromHiro(id: string): Promise<InscriptionInfo> {
+  const url = new URL(`/inscriptions/${id}`, hiroUrlBase);
+  const data = await fetchUrl(url.toString()).catch(() => {});
+  if (data === undefined || Object.keys(data).length === 0) {
+    throw new Error(`fetchInfoFromHiro: ${url} returned no data`);
+  }
+  const apiData = data as HiroApiInscription;
+  const info: InscriptionInfo = {
+    id: apiData.id,
+    number: apiData.number,
+    address: apiData.address,
+    content_type: apiData.content_type,
+    content_length: apiData.content_length,
+    genesis_block_height: apiData.genesis_block_height,
+    genesis_tx_id: apiData.tx_id,
+    timestamp: new Date(apiData.timestamp).toISOString(),
+  };
+  return info;
 }
 
 // fetches ordapi.xyz inscription results
@@ -42,8 +81,17 @@ export async function fetchInfoFromOrdApi(id: string): Promise<InscriptionInfo> 
   return info;
 }
 
+// fetchs hiro api content results
+export async function fetchContentFromHiro(id: string): Promise<Response> {
+  const url = new URL(`/ordinals/v1/inscriptions/${id}/content`, hiroUrlBase);
+  const response = await throttle(() => fetch(url.toString()).catch(() => {}));
+  if (response === undefined) {
+    throw new Error(`fetchContentFromHiro: ${url} returned no data`);
+  }
+  return response;
+}
+
 // fetches ordinals.com/content results
-// and not sure what to do with types here
 export async function fetchContentFromOrdinals(id: string): Promise<Response> {
   const url = new URL(`/content/${id}`, ordinalsUrlBase);
   const response = await throttle(() => fetch(url.toString()).catch(() => {}));
@@ -52,17 +100,6 @@ export async function fetchContentFromOrdinals(id: string): Promise<Response> {
     throw new Error(`fetchContentFromOrdinals: ${url} returned no data`);
   }
   return response;
-}
-
-// both support /inscription and /content paths
-export const ordinalsUrlBase = new URL('https://ordinals.com/');
-export const ordApiUrlBase = new URL('https://ordapi.xyz/');
-
-// takes data and status code and returns a Response object
-export function createResponse(data: unknown, status = 200) {
-  return new Response(typeof data === 'string' ? data : JSON.stringify(data, null, 2), {
-    status: status,
-  });
 }
 
 // distinguish content-type vs mime-type

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -33,7 +33,6 @@ export function createResponse(data: unknown, status = 200) {
 // and formats/returns them as InscriptionInfo
 export async function fetchInfoFromHiro(id: string): Promise<InscriptionInfo> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}`, hiroUrlBase);
-  //console.log(`fetching info: ${url.toString()}`);
   const data = await fetchUrl(url.toString()).catch(() => {});
   if (data === undefined || Object.keys(data).length === 0) {
     throw new Error(`fetchInfoFromHiro: ${url} returned no data`);
@@ -80,9 +79,7 @@ export async function fetchInfoFromOrdApi(id: string): Promise<InscriptionInfo> 
 // fetchs hiro api content results
 export async function fetchContentFromHiro(id: string): Promise<Response> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}/content`, hiroUrlBase);
-  console.log(`fetching content: ${url.toString()}`);
   const response = await fetch(url.toString()).catch(() => {});
-  console.log(`fetch complete`);
   if (response === undefined) {
     throw new Error(`fetchContentFromHiro: ${url} returned no data`);
   }

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -29,6 +29,13 @@ export type OrdApiInscription = {
 };
 
 // returned from api.hiro.so
+export type HiroApiResponse = {
+  limit: number;
+  offset: number;
+  total: number;
+  results: HiroApiInscription[];
+};
+
 export type HiroApiInscription = {
   id: string;
   number: number;
@@ -37,18 +44,19 @@ export type HiroApiInscription = {
   genesis_block_height: number;
   genesis_block_hash: string;
   genesis_tx_id: string;
-  genesis_fee: string; // number?
+  genesis_fee: string;
   genesis_timestamp: number;
+  tx_id: string;
   location: string;
   output: string;
-  value: string; // is this the content?
-  offset: string; // number?
-  sat_ordinal: string; // number?
+  value: string;
+  offset: string;
+  sat_ordinal: string;
   sat_rarity: string;
   sat_coinbase_height: number;
   mime_type: string;
   content_type: string;
-  content_length: 59;
+  content_length: number;
   timestamp: number;
 };
 

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -3,7 +3,8 @@ import { KVNamespace } from '@cloudflare/workers-types';
 // KV binding
 export interface Env {
   ORD_NEWS_INDEX: KVNamespace;
-  PREVIEW: boolean;
+  PREVIEW: string;
+  CF_PAGES_BRANCH: string;
 }
 
 // returned from ordapi.xyz


### PR DESCRIPTION
This sets up a structure where one API gets queried for the data, and if it fails, a second API is queried for the same data. This is a precursor to having a little more resilient setup both in terms of data sourcing and fallback mechanisms.