### PR TITLE
Implement new index

### DIFF
--- a/functions/api/content/[id].ts
+++ b/functions/api/content/[id].ts
@@ -7,13 +7,9 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
     // setup and config
     const { env } = context;
     const id = String(context.params.id);
-    const inscriptionData = await getInscription(env, id).catch(() => undefined);
-    if (
-      inscriptionData === undefined ||
-      Object.keys(inscriptionData).length === 0 ||
-      inscriptionData.content.body === null
-    ) {
-      return createResponse(`Inscription content not found for ${id}`, 404);
+    const inscriptionData = await getInscription(env, id);
+    if (inscriptionData.content.body === null) {
+      throw new Error(`Inscription content not found for ${id}`);
     }
     let { readable, writable } = new TransformStream();
     inscriptionData.content.body.pipeTo(writable);
@@ -23,6 +19,6 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
       },
     });
   } catch (err) {
-    return createResponse(String(err), 500);
+    return createResponse(String(err), 404);
   }
 }

--- a/functions/api/content/[id].ts
+++ b/functions/api/content/[id].ts
@@ -7,10 +7,13 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
     // setup and config
     const { env } = context;
     const id = String(context.params.id);
+    // get the inscription data
     const inscriptionData = await getInscription(env, id);
+    // verify content body exists
     if (inscriptionData.content.body === null) {
       throw new Error(`Inscription content not found for ${id}`);
     }
+    // return the content
     let { readable, writable } = new TransformStream();
     inscriptionData.content.body.pipeTo(writable);
     return new Response(readable, {
@@ -19,6 +22,7 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
       },
     });
   } catch (err) {
+    // return the error
     return createResponse(String(err), 404);
   }
 }

--- a/functions/api/data/[id].ts
+++ b/functions/api/data/[id].ts
@@ -30,7 +30,7 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
         signature: contentObj.signature,
       };
     } catch (err) {
-      throw err;
+      throw new Error(`Unable to parse news inscription for ${id}`);
     }
     // get the metadata from inscription
     const meta = (({ content, ...inscriptionData }) => inscriptionData)(

--- a/functions/api/data/[id].ts
+++ b/functions/api/data/[id].ts
@@ -7,11 +7,15 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
     // setup and config
     const { env } = context;
     const id = String(context.params.id);
-    const inscriptionData = await getInscription(env, id).catch(() => undefined);
-    if (inscriptionData === undefined || inscriptionData.content.body === null) {
-      return createResponse(`Inscription data not found for ${id}`, 404);
+    // get the inscription data
+    const inscriptionData = await getInscription(env, id);
+    // verify content body exists
+    if (inscriptionData.content.body === null) {
+      throw new Error(`Inscription content not found for ${id}`);
     }
+    // get the content
     const content = await inscriptionData.content.text();
+    // try to parse it as a news ordinal
     let news: OrdinalNews;
     try {
       const contentObj = JSON.parse(content);
@@ -26,13 +30,16 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
         signature: contentObj.signature,
       };
     } catch (err) {
-      return createResponse(`Unable to parse news inscription for ${id}`, 404);
+      throw err;
     }
+    // get the metadata from inscription
     const meta = (({ content, ...inscriptionData }) => inscriptionData)(
       inscriptionData
     ) as InscriptionMeta;
+    // return the metadata and news data
     return createResponse({ ...meta, ...news });
   } catch (err) {
-    return createResponse(String(err), 500);
+    // return the error
+    return createResponse(String(err), 404);
   }
 }

--- a/functions/api/data/ord-list.ts
+++ b/functions/api/data/ord-list.ts
@@ -14,23 +14,7 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
       prefix: prefix ?? undefined,
       limit: limit ? parseInt(limit) : undefined,
     };
-    //let complete = false;
-    //const keys: KVNamespaceListKey<unknown, string>[] = [];
-    const kvKeyList = await env.ORD_LIST.list({ ...options });
-    /*
-    do {
-      if (kvKeyList.keys.length > 0) {
-        keys.push(...kvKeyList.keys);
-      }
-      if (kvKeyList.list_complete) {
-        complete = true;
-      }
-      if ('cursor' in kvKeyList) {
-        options.cursor = kvKeyList.cursor;
-      }
-    } while (complete === false);
-    */
-
+    const kvKeyList = await env.ORD_LIST_V2.list({ ...options });
     return createResponse(kvKeyList);
   } catch (err) {
     return createResponse(err, 500);

--- a/functions/api/data/ord-news.ts
+++ b/functions/api/data/ord-news.ts
@@ -14,22 +14,7 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
       prefix: prefix ?? undefined,
       limit: limit ? parseInt(limit) : undefined,
     };
-    // let complete = false;
-    // const keys: KVNamespaceListKey<unknown, string>[] = [];
-    const kvKeyList = await env.ORD_NEWS.list({ ...options });
-    /*
-    do {
-      if (kvKeyList.keys.length > 0) {
-        keys.push(...kvKeyList.keys);
-      }
-      if (kvKeyList.list_complete) {
-        complete = true;
-      }
-      if ('cursor' in kvKeyList) {
-        options.cursor = kvKeyList.cursor;
-      }
-    } while (complete === false);
-    */
+    const kvKeyList = await env.ORD_NEWS_V2.list({ ...options });
     return createResponse(kvKeyList);
   } catch (err) {
     return createResponse(err, 500);

--- a/functions/api/info/[id].ts
+++ b/functions/api/info/[id].ts
@@ -7,20 +7,16 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
     // setup and config
     const { env } = context;
     const id = String(context.params.id);
-    console.log(`id: ${id}`);
-    const inscriptionData = await getInscription(env, id).catch(err => {
-      console.log(String(err));
-      return undefined;
-    });
-    console.log(`inscriptionData: ${JSON.stringify(inscriptionData)}`);
-    if (inscriptionData === undefined) {
-      return createResponse(`Inscription info not found for ${id}`, 404);
-    }
+    // get the inscription data
+    const inscriptionData = await getInscription(env, id);
+    // get the metadata from inscription
     const meta = (({ content, ...inscriptionData }) => inscriptionData)(
       inscriptionData
     ) as InscriptionMeta;
+    // return the metadata
     return createResponse(meta);
   } catch (err) {
-    return createResponse(String(err), 500);
+    // return the error
+    return createResponse(String(err), 404);
   }
 }

--- a/functions/api/info/[id].ts
+++ b/functions/api/info/[id].ts
@@ -7,7 +7,12 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
     // setup and config
     const { env } = context;
     const id = String(context.params.id);
-    const inscriptionData = await getInscription(env, id).catch(() => undefined);
+    console.log(`id: ${id}`);
+    const inscriptionData = await getInscription(env, id).catch(err => {
+      console.log(String(err));
+      return undefined;
+    });
+    console.log(`inscriptionData: ${JSON.stringify(inscriptionData)}`);
     if (inscriptionData === undefined) {
       return createResponse(`Inscription info not found for ${id}`, 404);
     }

--- a/functions/api/news/[id].ts
+++ b/functions/api/news/[id].ts
@@ -38,7 +38,7 @@ export async function onRequest(context: EventContext<Env, any, any>): Promise<R
         headers: { 'Content-Type': 'text/html' },
       });
     } catch (err) {
-      throw err;
+      throw new Error(`Unable to parse news inscription for ${id}`);
     }
   } catch (err) {
     // return the error

--- a/functions/api/news/[id].ts
+++ b/functions/api/news/[id].ts
@@ -4,53 +4,44 @@ import { createResponse, getInscription } from '../../../lib/api-helpers';
 import { Env, OrdinalNews } from '../../../lib/api-types';
 
 export async function onRequest(context: EventContext<Env, any, any>): Promise<Response> {
-  const { env } = context;
-  const id = String(context.params.id);
-  const inscriptionData = await getInscription(env, id);
-  if (inscriptionData === undefined || inscriptionData.content.body === null) {
-    return createResponse(`Inscription content not found for ${id}`, 404);
-  }
-  const content = await inscriptionData.content.text();
-  let news: OrdinalNews;
   try {
-    const contentObj = JSON.parse(content);
-    news = {
-      p: contentObj.p,
-      op: contentObj.op,
-      title: contentObj.title,
-      url: contentObj.url,
-      body: contentObj.body,
-      author: contentObj.author,
-      authorAddress: contentObj.authorAddress,
-      signature: contentObj.signature,
-    };
+    const { env } = context;
+    const id = String(context.params.id);
+    // get the inscription data
+    const inscriptionData = await getInscription(env, id);
+    // verify content body exists
+    if (inscriptionData.content.body === null) {
+      throw new Error(`Inscription content not found for ${id}`);
+    }
+    // get the content
+    const content = await inscriptionData.content.text();
+    // try to parse it as a news ordinal
+    let news: OrdinalNews;
+    try {
+      const contentObj = JSON.parse(content);
+      news = {
+        p: contentObj.p,
+        op: contentObj.op,
+        title: contentObj.title,
+        url: contentObj.url,
+        body: contentObj.body,
+        author: contentObj.author,
+        authorAddress: contentObj.authorAddress,
+        signature: contentObj.signature,
+      };
+      if (!news.body) {
+        throw new Error(`No body found for ${id}`);
+      }
+      const md = new MarkdownIt();
+      return new Response(md.render(news.body), {
+        status: 200,
+        headers: { 'Content-Type': 'text/html' },
+      });
+    } catch (err) {
+      throw err;
+    }
   } catch (err) {
-    return createResponse(`Unable to parse news inscription for ${id}`, 404);
+    // return the error
+    return createResponse(String(err), 404);
   }
-
-  const md = new MarkdownIt();
-  if (!news.body) {
-    return createResponse(`No body found for ${id}`, 404);
-  }
-  return new Response(md.render(news.body), {
-    status: 200,
-    headers: { 'Content-Type': 'text/html' },
-  });
 }
-
-/*
-OLD CODE RETURNING HTML PAGE
-
-const htmlStart = `<html><head><title>${news.title} - Ordinal News Standard</title><style>body { background-color: #000; color: #fff; font-weight: 350; line-height: 1.6; font-size: 1.5em; } a, a:active, a:visited { color: #1eaab4 } a:hover { color: #2ad0db }</style></head><body>`;
-  let formattedNews = `<h1>${news.title}</h1>`;
-  if (news.author) formattedNews += `<span style="font-style:italic">Author: ${news.author}</span>`;
-  if (news.url) formattedNews += `<br /><a href="${news.url}">${news.url}</a>`;
-  if (news.body) formattedNews += `<hr />\n${md.render(news.body)}`;
-  const htmlEnd = `</body></html>`;
-  // TODO: return just md.render(news.body) -> then render on another page?
-  return new Response(htmlStart + formattedNews + htmlEnd, {
-    status: 200,
-    headers: { 'Content-Type': 'text/html' },
-  });
-
-*/

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -73,8 +73,12 @@ export async function getInscription(
     console.log(`getInscription: unable to retrieve from V1 KV key`);
     // fetch metadata and content from Hiro API
     // works with inscription ID or inscription number
-    metadata = await fetchMetaFromHiro(id).catch(() => undefined);
-    content = await fetchContentFromHiro(id).catch(() => undefined);
+    metadata = await fetchMetaFromHiro(id).catch(err => {
+      throw new Error(`getInscription: metadata not found for ${id}\n${String(err)}`);
+    });
+    content = await fetchContentFromHiro(id).catch(err => {
+      throw new Error(`getInscription: content not found for ${id}\n${String(err)}`);
+    });
   }
   // check that data was actually returned
   if (metadata === undefined || Object.keys(metadata).length === 0) {

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -83,7 +83,8 @@ export async function getInscription(
       metadata = await fetchMetaFromHiro(id);
       content = await fetchContentFromHiro(id);
     } catch (err) {
-      throw new Error(err);
+      // catch and surface errors if any
+      throw err;
     }
   }
 
@@ -141,7 +142,7 @@ export async function fetchMetaFromHiro(id: string): Promise<InscriptionMeta> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}`, hiroApiUrl);
   const data = await fetchUrl(url.toString()).catch(() => {});
   if (data === undefined || Object.keys(data).length === 0) {
-    throw new Error(`fetchMetaFromHiro: returned no data:\nID: ${id}\nURL: ${url}`);
+    throw new Error(`Unable to fetch metadata from Hiro API:\nID: ${id}\nURL: ${url}`);
   }
   const apiData = data as HiroApiInscription;
   const metadata: InscriptionMeta = {
@@ -167,7 +168,7 @@ export async function fetchContentFromHiro(id: string): Promise<Response> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}/content`, hiroApiUrl);
   const response = await fetch(url.toString()).catch(() => undefined);
   if (response === undefined) {
-    throw new Error(`fetchContentFromHiro: returned no data\nID: ${id}\nURL: ${url}`);
+    throw new Error(`Unable to fetch content from Hiro API:\nID: ${id}\nURL: ${url}`);
   }
   return response;
 }

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -37,6 +37,15 @@ export function createResponse(data: unknown, status = 200) {
   });
 }
 
+// takes a number and returns it with padding for consistent formatting/sorting
+export function padNumber(num: number, size = 10) {
+  let s = String(num);
+  if (s.length > size)
+    throw new Error(`Number ${num} is larger than the specified padding size of ${size}`);
+  while (s.length < size) s = '0' + s;
+  return s;
+}
+
 /////////////////////////
 // GETTERS
 /////////////////////////
@@ -88,6 +97,9 @@ export async function getInscription(
     }
   }
 
+  // create the inscription key name
+  const keyName = `inscription-${padNumber(metadata.number)}`;
+
   // test if valid by Ordinals News Standard
   const newsContent = content.clone();
   const contentString = new TextDecoder().decode(await newsContent.arrayBuffer());
@@ -109,11 +121,7 @@ export async function getInscription(
     if (news.p === 'ons' && news.title) {
       // if yes, store in V2 KV key for news only
       const kvNewsContent = content.clone();
-      await env.ORD_NEWS_V2.put(
-        `inscription-${metadata.number}`,
-        await kvNewsContent.arrayBuffer(),
-        { metadata }
-      );
+      await env.ORD_NEWS_V2.put(keyName, await kvNewsContent.arrayBuffer(), { metadata });
     }
   } catch (err) {
     console.log(`Not a valid news inscription: ${id}\n${err}`);
@@ -121,7 +129,7 @@ export async function getInscription(
 
   // store in general V2 KV key for inscriptions
   const kvContent = content.clone();
-  await env.ORD_LIST_V2.put(`inscription-${metadata.number}`, await kvContent.arrayBuffer(), {
+  await env.ORD_LIST_V2.put(keyName, await kvContent.arrayBuffer(), {
     metadata,
   });
 

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -83,7 +83,7 @@ export async function getInscription(
       metadata = await fetchMetaFromHiro(id);
       content = await fetchContentFromHiro(id);
     } catch (err) {
-      throw new Error(`getInscription: unable to retrieve from Hiro API\n${id}\n${String(err)}`);
+      throw new Error(err);
     }
   }
 
@@ -141,7 +141,7 @@ export async function fetchMetaFromHiro(id: string): Promise<InscriptionMeta> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}`, hiroApiUrl);
   const data = await fetchUrl(url.toString()).catch(() => {});
   if (data === undefined || Object.keys(data).length === 0) {
-    throw new Error(`fetchMetaFromHiro: returned no data: ${url}`);
+    throw new Error(`fetchMetaFromHiro: returned no data:\nID: ${id}\nURL: ${url}`);
   }
   const apiData = data as HiroApiInscription;
   const metadata: InscriptionMeta = {
@@ -167,7 +167,7 @@ export async function fetchContentFromHiro(id: string): Promise<Response> {
   const url = new URL(`/ordinals/v1/inscriptions/${id}/content`, hiroApiUrl);
   const response = await fetch(url.toString()).catch(() => undefined);
   if (response === undefined) {
-    throw new Error(`fetchContentFromHiro: returned no data: ${url}`);
+    throw new Error(`fetchContentFromHiro: returned no data\nID: ${id}\nURL: ${url}`);
   }
   return response;
 }

--- a/lib/api-types.ts
+++ b/lib/api-types.ts
@@ -2,35 +2,11 @@ import { KVNamespace } from '@cloudflare/workers-types';
 
 // KV binding
 export interface Env {
-  ORD_DATA: KVNamespace;
   ORD_LIST: KVNamespace;
   ORD_NEWS: KVNamespace;
-  ORD_NEWS_INDEX: KVNamespace;
-  PREVIEW: string;
-  CF_PAGES_BRANCH: string;
+  ORD_LIST_V2: KVNamespace;
+  ORD_NEWS_V2: KVNamespace;
 }
-
-// returned from ordapi.xyz
-// TODO: changed since last look?
-export type OrdApiInscription = {
-  address: string;
-  content: string;
-  'content length': string;
-  'content type': string;
-  'genesis fee': string;
-  'genesis height': string;
-  'genesis transaction': string;
-  id: string;
-  inscription_number: number;
-  location: string;
-  offset: string;
-  output: string;
-  'output value': string;
-  preview: string;
-  sat: string;
-  timestamp: Date;
-  title: string;
-};
 
 // returned from api.hiro.so
 export type HiroApiResponse = {
@@ -64,21 +40,9 @@ export type HiroApiInscription = {
   timestamp: number;
 };
 
-// defining the news standard in TS
-export type OrdinalNews = {
-  p: string;
-  op: string;
-  title: string;
-  url?: string;
-  body?: string;
-  author?: string;
-  authorAddress?: string;
-  signature?: string;
-};
-
 // metadata for inscription stored in KV
 export type InscriptionMeta = {
-  // inscription
+  // inscription details
   id: string;
   number: number;
   address: string;
@@ -95,4 +59,16 @@ export type InscriptionMeta = {
 
 export type InscriptionContent = {
   content: Response;
+};
+
+// defining the news standard in TS
+export type OrdinalNews = {
+  p: string;
+  op: string;
+  title: string;
+  url?: string;
+  body?: string;
+  author?: string;
+  authorAddress?: string;
+  signature?: string;
 };

--- a/src/routes/recent-news.tsx
+++ b/src/routes/recent-news.tsx
@@ -5,7 +5,9 @@ import { InscriptionMeta, OrdinalNews } from '../../lib/api-types';
 import { Link } from 'react-router-dom';
 import StatsCard from '../components/stats-card';
 
-const apiUrl = new URL('https://inscribe.news/');
+// const apiUrl = new URL('https://inscribe.news/');
+// use dev api temporarily
+const apiUrl = new URL('https://feat-indexer-v2.ordinal-news-client.pages.dev/');
 
 async function getRecentNews() {
   const result = await fetch(new URL(`/api/data/ord-news`, apiUrl).toString());

--- a/src/routes/recent-news.tsx
+++ b/src/routes/recent-news.tsx
@@ -5,9 +5,7 @@ import { InscriptionMeta, OrdinalNews } from '../../lib/api-types';
 import { Link } from 'react-router-dom';
 import StatsCard from '../components/stats-card';
 
-// const apiUrl = new URL('https://inscribe.news/');
-// use dev api temporarily
-const apiUrl = new URL('https://feat-indexer-v2.ordinal-news-client.pages.dev/');
+const apiUrl = new URL('https://inscribe.news/');
 
 async function getRecentNews() {
   const result = await fetch(new URL(`/api/data/ord-news`, apiUrl).toString());


### PR DESCRIPTION
The original index was polluted with both inscription IDs and numbers due to a subtle bug, causing duplication if an inscription was looked up using both values.

In addition, the keys are sorted alphabetically, so it is not possible to get a sequential list of inscription numbers on each call, and all the data must instead be queried then sorted (450k+ records as of writing this).

This introduces a new KV key/value store for ORD_LIST_V2 and ORD_NEWS_V2, as well as implements fetching from the original V1 keys to help with data migration.

It also changes the format of the key name from using the inscription ID to `inscription-NUM` in hopes this will help with the sorting and filtering available through the KVNamespaceListOptions.