### PR TITLE
Replace content links in body

### DIFF
--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -46,6 +46,11 @@ export function padNumber(num: number, size = 10) {
   return s;
 }
 
+// replaces relative /content links with /api/content links
+export function replaceContentLinks(content: string) {
+  return content.replace(/\/content\//g, '/api/content/');
+}
+
 /////////////////////////
 // GETTERS
 /////////////////////////

--- a/lib/api-helpers.ts
+++ b/lib/api-helpers.ts
@@ -48,7 +48,7 @@ export function padNumber(num: number, size = 10) {
 
 // replaces relative /content links with /api/content links
 export function replaceContentLinks(content: string) {
-  return content.replace(/\/content\//g, '/api/content/');
+  return content.replace(/="\/content\//g, '="/api/content/');
 }
 
 /////////////////////////

--- a/src/routes/view-news.tsx
+++ b/src/routes/view-news.tsx
@@ -12,6 +12,7 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import { replaceContentLinks } from '../../lib/api-helpers';
 import { InscriptionMeta, OrdinalNews } from '../../lib/api-types';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
@@ -244,7 +245,7 @@ export default function ViewNews() {
           />
           <ReactMarkdown
             components={ChakraUIRenderer()}
-            children={news.body}
+            children={replaceContentLinks(news.body)}
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[rehypeRaw]}
             className="ord-news"


### PR DESCRIPTION
If we replace `/content` with `/api/content` then recursive content should be supported natively.